### PR TITLE
Fix buildpack.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -103,7 +103,7 @@ BP_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPT_DIR=$BP_DIR/../opt/
 
 JDK_DIR="$BUILD_DIR/.jdk"
-JVM_COMMON_URL="https://raw.githubusercontent.com/heroku/heroku-buildpack-jvm-common/master/"
+JVM_COMMON_URL="https://raw.githubusercontent.com/heroku/heroku-buildpack-jvm-common/main/"
 
 install_adoptopenjdk "$JDK_DIR"
 create_profile_scripts "$BUILD_DIR" "$JVM_COMMON_URL"


### PR DESCRIPTION
Buildpack recently broke due to one of the recent changes in an upstream respository.

Logs before change:
```
2020-07-31T19:15:59.298606+00:00 heroku[run.1]: State changed from starting to up
2020-07-31T19:16:01.220758+00:00 heroku[run.1]: Process exited with status 127
2020-07-31T19:16:01.257599+00:00 heroku[run.1]: State changed from up to crashed
2020-07-31T19:16:01.154664+00:00 app[run.1]: /app/.profile.d/adoptopenjdk.sh: line 1: 404:: command not found
2020-07-31T19:16:01.155348+00:00 app[run.1]: /app/.profile.d/jdbc.sh: line 1: 404:: command not found
```